### PR TITLE
fallback API URL

### DIFF
--- a/maketestsgofaster/cloud/client.py
+++ b/maketestsgofaster/cloud/client.py
@@ -12,13 +12,13 @@ class Client():
         self.api_key = settings.api_key
         self.api_retries = settings.api_retries
         self.api_timeout = settings.api_timeout
-        self.api_url = settings.api_url
+        self.api_urls = settings.api_urls
         self.build_id = settings.build_id
         self.build_worker = settings.build_worker
         self.user_agent = settings.client_name + '/' + settings.client_version
 
     def send(self, path, data):
-        url = self.api_url + path
+        url = self.api_urls[0] + path
         body = zlib.compress(json.dumps(data).encode('utf8'))
         headers = {
             'Accept': 'application/json',

--- a/maketestsgofaster/cloud/client.py
+++ b/maketestsgofaster/cloud/client.py
@@ -33,7 +33,7 @@ class Client():
         result = None
         last_err = None
         wait_before_retry = 0
-        while result is None and attempts < self.api_retries:
+        while result is None and attempts < self.api_retries + 1:
             url = self.api_urls[0] + path
 
             if wait_before_retry >= 1:

--- a/maketestsgofaster/cloud/settings.py
+++ b/maketestsgofaster/cloud/settings.py
@@ -14,7 +14,9 @@ class Settings():
         self.api_key = self.__parse('api_key')
         self.api_retries = int(self.__parse('api_retries', 5))
         self.api_timeout = int(self.__parse('api_timeout', 60))
-        self.api_url = self.__parse('api_url', 'https://scheduler.maketestsgofaster.com')
+        self.api_urls = self.__parse('api_url', ['https://scheduler.maketestsgofaster.com', 'https://scheduler.maketestsgofaster.co'])
+        if not isinstance(self.api_urls, list):
+            self.api_urls = [self.api_urls]
 
         self.build_dir = self.__parse('build_dir', os.getcwd())
         self.build_id = self.__parse('build_id')

--- a/tests/IT/integration_test.py
+++ b/tests/IT/integration_test.py
@@ -198,44 +198,6 @@ def test_give_up_when_server_unreachable(config):
 
 
 @pytest.mark.e2e
-def test_give_up_when_server_returns_errors(config, server):
-    with pytest.raises(RuntimeError, match='server communication error - status code: 500, request id: <unique-request-id>'):
-        settings = Settings(Env.create({
-            'api_key': 'error',
-            'api_timeout': '2',
-            'api_retries': '1',
-            'api_url': server.url,
-            'build_id': '4242',
-            'vcs_branch': 'master',
-            'vcs_revision': 'asd43da',
-        }))
-        scheduler = Scheduler(settings)
-
-        server.next_response(500, {})
-
-        scheduler.next_file()
-
-
-@pytest.mark.e2e
-def test_give_up_when_gateway_error(config, server):
-    with pytest.raises(RuntimeError, match='server communication error - status code: 502, request id: None'):
-        settings = Settings(Env.create({
-            'api_key': 'error',
-            'api_timeout': '2',
-            'api_retries': '1',
-            'api_url': server.url,
-            'build_id': '4242',
-            'vcs_branch': 'master',
-            'vcs_revision': 'asd43da',
-        }))
-        scheduler = Scheduler(settings)
-
-        server.next_response(502, {})
-
-        scheduler.next_file()
-
-
-@pytest.mark.e2e
 def test_stop_on_empty_schedule(config, server):
     settings = Settings(Env.create({
         'api_key': '42',

--- a/tests/unit/cloud/client_test.py
+++ b/tests/unit/cloud/client_test.py
@@ -29,10 +29,10 @@ class TestClient():
 
     def test_give_up_when_persistent_server_error(self):
         client = MockClient([
-            (MockResponse(502), MOCK_CONTENT),
-            (MockResponse(502), MOCK_CONTENT),
-            (MockResponse(502), MOCK_CONTENT),
-            (MockResponse(502), MOCK_CONTENT),
+            (MockResponse(500), MOCK_CONTENT),
+            (MockResponse(500), MOCK_CONTENT),
+            (MockResponse(500), MOCK_CONTENT),
+            (MockResponse(500), MOCK_CONTENT),
         ])
 
         with pytest.raises(RuntimeError, match='server communication error - status code: 500, request id: REQ_ID'):
@@ -53,7 +53,7 @@ class TestClient():
 class MockClient(Client):
     def __init__(self, responses, settings=Settings(Env.create({
         'api_retries': '3',
-        'api_timeout': '2',
+        'api_timeout': '1',
     }))):
         super().__init__(settings)
         self.responses = responses

--- a/tests/unit/cloud/client_test.py
+++ b/tests/unit/cloud/client_test.py
@@ -1,0 +1,79 @@
+import pytest
+
+from maketestsgofaster.cloud.client import Client
+from maketestsgofaster.cloud.env import Env
+from maketestsgofaster.cloud.settings import Settings
+
+
+MOCK_CONTENT = """{"message": "Hello world!"}""".encode()
+
+
+class TestClient():
+
+    def test_send_successfully(self):
+        client = MockClient([(MockResponse(200), MOCK_CONTENT)])
+        res = client.send('/endpoint', {})
+        assert res == {'message': 'Hello world!'}
+
+    def test_switch_api_url_for_connection_problems(self):
+        client = MockClient([
+            IOError('unable to reach server'),
+            (MockResponse(500), MOCK_CONTENT),
+            IOError('unable to reach server'),
+            (MockResponse(200), MOCK_CONTENT),
+        ])
+        client.send('/endpoint', {})
+        assert client.requests[0]['url'] != client.requests[1]['url']  # switch URL for connection issue
+        assert client.requests[1]['url'] == client.requests[2]['url']  # keep URL for API error
+        assert client.requests[2]['url'] != client.requests[3]['url']  # switch again for connection issue
+
+    def test_give_up_when_persistent_server_error(self):
+        client = MockClient([
+            (MockResponse(502), MOCK_CONTENT),
+            (MockResponse(502), MOCK_CONTENT),
+            (MockResponse(502), MOCK_CONTENT),
+            (MockResponse(502), MOCK_CONTENT),
+        ])
+
+        with pytest.raises(RuntimeError, match='server communication error - status code: 500, request id: REQ_ID'):
+            client.send('/endpoint', {})
+
+    def test_give_up_when_persistent_connection_error(self):
+        client = MockClient([
+            IOError('unable to reach server'),
+            IOError('unable to reach server'),
+            IOError('unable to reach server'),
+            IOError('unable to reach server'),
+        ])
+
+        with pytest.raises(RuntimeError, match='server communication error - unable to reach server'):
+            client.send('/endpoint', {})
+
+
+class MockClient(Client):
+    def __init__(self, responses, settings=Settings(Env.create({
+        'api_retries': '3',
+        'api_timeout': '2',
+    }))):
+        super().__init__(settings)
+        self.responses = responses
+        self.requests = []
+
+    def request(self, url, headers, body, timeout):
+        self.requests.append({'url': url, 'headers': headers, 'body': body})
+        head, tail = self.responses[0], self.responses[1:]
+        self.responses = tail
+        if isinstance(head, Exception):
+            raise head
+        return head
+
+
+class MockResponse():
+    def __init__(self, status, data={
+        'x-request-id': 'REQ_ID',
+    }):
+        self.status = status
+        self.data = data
+
+    def get(self, key):
+        return self.data.get(key)

--- a/tests/unit/cloud/settings_test.py
+++ b/tests/unit/cloud/settings_test.py
@@ -37,13 +37,11 @@ class TestInitSettings():
         settings = Settings(MockedEnv({
             'api_url': 'http://0.0.0.0',
         }))
-        assert settings.api_url == 'http://0.0.0.0'
+        assert settings.api_urls == ['http://0.0.0.0']
 
     def test_api_url_default(self):
-        settings = Settings(MockedEnv({
-            'api_url': 'https://scheduler.maketestsgofaster.com',
-        }))
-        assert settings.api_url == 'https://scheduler.maketestsgofaster.com'
+        settings = Settings(MockedEnv())
+        assert settings.api_urls == ['https://scheduler.maketestsgofaster.com', 'https://scheduler.maketestsgofaster.co']
 
     def test_build_id(self):
         settings = Settings(MockedEnv({


### PR DESCRIPTION
When there are connection issues (ie due to DNS problems), try another API URL.